### PR TITLE
fix(extras): file-size-human-readable wrong-type-argument `nil`

### DIFF
--- a/extensions/dirvish-extras.el
+++ b/extensions/dirvish-extras.el
@@ -180,11 +180,10 @@ The value can be one of: `plus', `arrow', `chevron'."
   "Get file size of file NAME from ATTRS."
   (let ((type (file-attribute-type attrs)))
     (cond ((stringp type)
-           (let ((truename (file-truename name)))
-             (condition-case nil
-                 (number-to-string (- (length (directory-files truename nil nil t)) 2))
-               (file-error (file-size-human-readable
-                            (file-attribute-size (file-attributes truename)))))))
+           (condition-case nil
+               (number-to-string (- (length (directory-files name nil nil t)) 2))
+             (file-error (file-size-human-readable
+                          (file-attribute-size (file-attributes name))))))
           (type (or (ignore-errors
                       (number-to-string
                        (- (length (directory-files name nil nil t)) 2))) "?"))


### PR DESCRIPTION
- remove `file-truename`

`file-attribute-size` with symbolic link that points to nonexistent
file return `nil`, which may break `dirvish--get-file-size-or-count`.
