### PR TITLE
Only insert group title for non empty groups

### DIFF
--- a/extensions/dirvish-emerge.el
+++ b/extensions/dirvish-emerge.el
@@ -372,7 +372,8 @@ DESC and HIDE are the group title and visibility respectively."
   "Insert GROUP to buffer."
   (pcase-let* ((`(,idx . ,files) group)
                (`(,desc _ ,hide) (nth (1- idx) dirvish-emerge-groups))
-               (beg (progn (insert (dirvish-emerge--group-heading desc hide) "\n")
+               (beg (progn (when files
+                             (insert (dirvish-emerge--group-heading desc hide) "\n"))
                            (point))))
     (dolist (file (reverse files)) (insert file "\n"))
     (let ((o (make-overlay beg (point))))


### PR DESCRIPTION
Small change as in the title.

BTW, there is on remaining issue with the highlighting. If I hide a group and then move to the next next group title, it is not highlighted. But I can highlight it if I press any key for moving to the right.