### PR TITLE
Only consider visible lines when rendering attributes

### DIFF
--- a/dirvish.el
+++ b/dirvish.el
@@ -726,7 +726,8 @@ If KEEP-CURRENT, do not kill the current directory buffer."
             (dolist (fn (if f-beg fns '(dirvish-attribute-hl-line-rd)))
               (funcall fn f-beg f-end f-str f-wid f-dir f-name
                        f-attrs f-type l-beg l-end remain hl-face)))
-          (forward-line 1))))))
+          (forward-line 1)
+          (while (invisible-p (point)) (forward-line 1)))))))
 
 (defun dirvish--deactivate-for-tab (tab _only-tab)
   "Deactivate all Dirvish sessions in TAB."
@@ -1228,7 +1229,8 @@ default implementation is `find-args' with simple formatting."
 (defun dirvish-update-body-h ()
   "Update UI of current Dirvish."
   (when-let ((dv (dirvish-curr)))
-    (cond ((eobp) (forward-line -1)) ((bobp) (forward-line 1)))
+    (cond ((eobp) (forward-line -1))
+          ((bobp) (forward-line (if dirvish--dired-free-space 2 1))))
     (dired-move-to-filename)
     (dirvish--render-attributes dv)
     (when-let ((filename (dired-get-filename nil t)))


### PR DESCRIPTION
The change to `dirvish--render-attributes` fixes the problem  thatif there are two many hidden lines on the screen the visible lines after them don't get their attributes rendered. This happens for example when a group with large number of files is hidden.

The change to `dirvish-update-body-h` is because at least in my case there are two hidden lines at the top of the buffer one with the name of the directory and other containing its size. Sometimes when beginning of buffer is hit the cursor gets stuck at the beginning of second visible line the first time. `(forward-line 2)` would be another solution but I am not sure if everyone has the same 2 lines at the beginning. 