### PR TITLE
shell quote filenames for git-msg

### DIFF
--- a/dirvish.el
+++ b/dirvish.el
@@ -1341,7 +1341,8 @@ If the buffer is not available, create it with `dired-noselect'."
                 (state (and bk (vc-state-refresh file bk)))
                 (git (and (eq bk 'Git) ; TODO: refactor this
                           (shell-command-to-string
-                           (format "git log -1 --pretty=%%s %s" file))))
+                           (format "git log -1 --pretty=%%s %s"
+                                   (shell-quote-argument file)))))
                 (tp (nth 0 attrs)))
            (cond
             ((eq t tp) (setq tp '(dir . nil)))


### PR DESCRIPTION
I ran into some issues with the git-msg on files with spaces in the
names. I've just added a small fix to help with that.