### PR TITLE
tramp file attribute info

### DIFF
--- a/extensions/dirvish-extras.el
+++ b/extensions/dirvish-extras.el
@@ -121,7 +121,10 @@ This value is passed to function `format-time-string'."
 (defun dirvish--get-file-size-or-count (name attrs)
   "Get file size of file NAME from ATTRS."
   (let ((type (file-attribute-type attrs)))
-    (cond ((dirvish-prop :tramp) (or (file-attribute-size attrs) "?"))
+    (cond ((and (dirvish-prop :tramp)
+                (not (tramp-local-host-p (dirvish-prop :tramp)))
+                (not dirvish-tramp-file-info))
+           (dirvish--file-size-add-spaces "?"))
           ((stringp type)
            (let ((count
                   (dirvish-attribute-cache name :f-count


### PR DESCRIPTION
I've attempted here to allow an opt-in for file attribute/sizes over
tramp with a custom variable. Also defaulting with localhost always
getting file attributes using the tramp file name as this solved some
permissions issues I was facing and I didn’t notice too much of a
slowdown.

Also, there is an included fix that addressed some `args-out-of-range`
errors I was getting. This can be fixed with ensuring the function
`dirvish--file-size-add-spaces` is included in all conditions of
`dirvish--get-file-size-or-count`.