### PR TITLE
Remove TRAMP method from file paths when copying from remote

### DIFF
--- a/extensions/dirvish-extras.el
+++ b/extensions/dirvish-extras.el
@@ -270,8 +270,9 @@ If MULTI-LINE, make every name occupy a separate line."
 If MULTI-LINE, make every path occupy a separate line."
   (interactive "P")
   (let* ((files (dired-get-marked-files))
-         (names (mapconcat #'concat files (if multi-line "\n" " "))))
-    (dirvish--kill-and-echo (if multi-line (concat "\n" names) names))))
+         (names (mapconcat #'concat files (if multi-line "\n" " ")))
+         (cleannames (if (file-remote-p default-directory) (replace-regexp-in-string (concat "/" tramp-default-method ":") "" names) names)))
+    (dirvish--kill-and-echo (if multi-line (concat "\n" cleannames) cleannames))))
 
 ;;;###autoload
 (defun dirvish-copy-file-directory ()


### PR DESCRIPTION
Humble PR here, it's my first one. I'm wondering if something like this would be reasonable to help with the current process of copying remote files? 

Currently, I might mark two files with paths "/ssh:user@host:/path/to/file1" and "/ssh:user@host:/path/to/file2" in a dirvish buffer, hit `f p` on my keyboard to copy the file paths, and then type `scp <control-v> . <RET>` into a local terminal to quickly get all of the files copied. However, the Emacs-ish file prefix "/ssh:" isn't compatible with scp.

This PR removes the file prefix based on whatever `tramp-default-method` is. So the paths to paste in the terminal look like "user@host:/path/to/file1" and "user@host:/path/to/file2". But I realize there could be some use case for the prefix as well which I'm unaware of. Chould this be controlled by a second universal argument or something like that?