### PR TITLE
Handle systems using fdfind by default

### DIFF
--- a/extensions/dirvish-fd.el
+++ b/extensions/dirvish-fd.el
@@ -19,6 +19,17 @@
   "Fd arguments inserted before user input."
   :type 'string :group 'dirvish)
 
+(defcustom dirvish-fd-program
+  (let ((fd (executable-find "fd"))
+        (fdfind (executable-find "fdfind")))
+    (cond
+     (fd fd)
+     (fdfind fdfind)
+     (t (warn "`dirvish-fd' requires `fd', please install it")
+        nil)))
+  "The default fd program."
+  :type 'string :group 'dirvish)
+
 (defcustom dirvish-fd-ls-program
   (let* ((ls (executable-find "ls"))
          (gls (executable-find "gls"))
@@ -55,7 +66,6 @@ should return a list of regular expressions."
 (defconst dirvish-fd-bufname "🔍%s📁%s📁")
 (defconst dirvish-fd--header
   (dirvish--mode-line-fmt-setter '(:left (fd-switches) :right (fd-timestamp fd-pwd " ")) t))
-(defvar dirvish-fd-program "fd" "The default fd program.")
 (defvar dirvish-fd-input-history nil "History list of fd input in the minibuffer.")
 (defvar dirvish-fd-debounce-timer nil)
 (defvar-local dirvish-fd--output nil)
@@ -106,8 +116,8 @@ should return a list of regular expressions."
   :init-value
   (lambda (o) (oset o value (split-string (or (dirvish-prop :fd-switches) ""))))
   [:description (lambda () (dirvish--format-menu-heading
-                       "Setup FD Switches"
-                       "Ignore Range (by default ignore ALL)
+                            "Setup FD Switches"
+                            "Ignore Range (by default ignore ALL
   VCS: .gitignore + .git/info/exclude + $HOME/.config/git/ignore
   ALL: VCS + .ignore + .fdignore + $HOME/.config/fd/ignore"))
    ["File types (multiple types can be included)"
@@ -215,9 +225,9 @@ should return a list of regular expressions."
 This command takes a while to index all the directories the first
 time you run it.  After the indexing, it fires up instantly."
   (interactive)
-  (unless (executable-find "fd")
+  (unless (executable-find dirvish-fd-program)
     (user-error "Dirvish: install `fd' to use this command"))
-  (let* ((command "fd -H -td -0 . /")
+  (let* ((command (concat dirvish-fd-program " -H -td -0 . /"))
          (output (shell-command-to-string command))
          (files-raw (split-string output "\0" t))
          (files (dirvish--append-metadata 'file files-raw))


### PR DESCRIPTION
Some systems such as Debian name fd as fdfind, which is currently not handled by Dirvish.

This commit changes `dirvish-fd-program` do a custom variable, indicating the user it is possible to customize its value. When initializing the variable, it tries to look for either `fd` or
`fdfind` and set it as its default value. If neither is found, emit a warning about `fd` not being installed.