### PR TITLE
fix(subtree): declare unused bindings as such

### DIFF
--- a/extensions/dirvish-subtree.el
+++ b/extensions/dirvish-subtree.el
@@ -205,11 +205,11 @@ When CLEAR, remove all subtrees in the buffer."
    finally
    (setq dirvish-subtree--overlays nil)
    (if (or clear (bound-and-true-p dirvish-emerge--group-overlays))
-       (cl-loop for (depth . name) in maps
+       (cl-loop for (_depth . name) in maps
                 when (dired-goto-file name)
                 do (progn (dired-next-line 1) (dirvish-subtree-remove))
                 finally (and index (dired-goto-file index)))
-     (cl-loop for (depth . name) in maps
+     (cl-loop for (_depth . name) in maps
               when (and (dirvish-subtree-expand-to name)
                         (not (dirvish-subtree--expanded-p)))
               do (dirvish-subtree--insert)


### PR DESCRIPTION
Fix:

```
In dirvish-subtree--revert:
lib/dirvish/extensions/dirvish-subtree.el:208:22: Warning: Unused lexical variable `depth'
lib/dirvish/extensions/dirvish-subtree.el:212:20: Warning: Unused lexical variable `depth'
```