### PR TITLE
Fix #158 : Delete emerge overlays when turning off the mode

### DIFF
--- a/extensions/dirvish-emerge.el
+++ b/extensions/dirvish-emerge.el
@@ -514,6 +514,8 @@ Press again to set the value for the group"))
         (add-hook 'dirvish-setup-hook #'dirvish-emerge--apply nil t)
         (unless dirvish-emerge--group-overlays (dirvish-emerge--apply)))
     (remove-hook 'dirvish-setup-hook #'dirvish-emerge--apply t)
+    (mapc #'delete-overlay dirvish-emerge--group-overlays)
+    (setq dirvish-emerge--group-overlays nil)
     (revert-buffer)))
 
 (defun dirvish-emerge--get-group-overlay ()


### PR DESCRIPTION
I had the same issue sometimes and this fixes it. I noticed that the overlays for the groups are still stored in `dirvish-emerge--group-overlays` though they appear as `overlay in no buffer` presumably because of revert.

P.S. I am somewhat surprised that reverting the buffer doesn't reset the buffer local variables.