### PR TITLE
Report error from fd to user

### DIFF
--- a/extensions/dirvish-fd.el
+++ b/extensions/dirvish-fd.el
@@ -340,6 +340,8 @@ value 16, let the user choose the root directory of their search."
   (pcase-let* ((buf (process-buffer proc))
                (success (eq (process-exit-status proc) 0))
                (`(,input ,dir ,dv) (process-get proc 'info)))
+    (when (not success)
+      (user-error "Dirvish fd error: %s" dirvish-fd--output))
     (unless (buffer-live-p buf)
       (cl-return-from dirvish-fd-proc-sentinel
         (message "`fd' process terminated")))


### PR DESCRIPTION
I stumbled upon this  [error](https://github.com/sharkdp/fd/issues/1179) in fd.
But before this fix no actual error from fd was reported. Actually it was not helpful error in `dirvish-fd-proc-sentinel`:
```
Debugger entered--Lisp error: (wrong-type-argument number-or-marker-p nil)
  dirvish-fd--parse-output()
  dirvish-fd-proc-sentinel(#<process fd> "exited abnormally with code 1\n")

```
Im not sure that it is the best way to handle errors, but at least It can save time when debugging original error.