### PR TITLE
fd: add function that reads pattern from user

### DIFF
--- a/extensions/dirvish-fd.el
+++ b/extensions/dirvish-fd.el
@@ -356,8 +356,7 @@ value 16, let the user choose the root directory of their search."
                 (propertize (current-time-string)
                             'face (if success 'success 'error))))
       (cond ((not input) (setq input (dirvish-fd--read-input)))
-            ((equal input "") (dirvish-update-body-h))
-            (t (dirvish-fd--narrow input (car (dirvish-prop :fd-arglist)))))
+            (t (dirvish-update-body-h)))
       (when (eq input 'cancelled)
         (cl-return-from dirvish-fd-proc-sentinel (kill-buffer buf)))
       (let ((bufname (dirvish-fd--bufname input dir dv)))
@@ -450,6 +449,7 @@ The command run is essentially:
                          "fd" buffer
                          `(,fd-program "--color=never"
                            ,@(or (split-string fd-switches) "")
+                           ,(or pattern "")
                            "--exec-batch" ,ls-program
                            ,@(or (split-string ls-switches) "")
                            "--quoting-style=literal" "--directory"))))
@@ -458,6 +458,15 @@ The command run is essentially:
         (dirvish-fd--argparser (split-string (or fd-switches "")))
         (process-put proc 'info (list pattern dir dv))))
     (dirvish-fd-switch-to-buffer buffer)))
+
+
+;;;###autoload
+(defun dirvish-fd-ask (dir pattern)
+  "The same as `dirvish-fd' but ask initial `pattern' via prompt. "
+  (interactive (list (and current-prefix-arg
+                          (read-directory-name "Fd target directory: " nil "" t))
+                     (read-from-minibuffer "Pattern: ")))
+  (dirvish-fd dir pattern))
 
 (provide 'dirvish-fd)
 ;;; dirvish-fd.el ends here


### PR DESCRIPTION
Also don't use `dirvish-fd--narrow` on fd output, unless input pattern is empty.
The default behavior of `dirvish-fd` was not changed: it  spits out all directory content and starts `dirvish-fd-narrow`.
 Rationale:
- filtering using emacs regex can be very slow on large number of fd output. Its better to filter as much as possible with the fast fd and if user needs fine-grade filtering he can use `dirvish-narrow`. For example on my `.local` directory that contains 150k files, it took forever to create `fd` output buffer.
- Some patterns that are supported by `fd` didn't work. For example `alt1|alt2` didn't work as expected.