### PR TITLE
use emacs-nerd-icons

### DIFF
--- a/dirvish.el
+++ b/dirvish.el
@@ -37,6 +37,7 @@ Dirvish ships with these attributes:
 
 - `subtree-state': A indicator for directory expanding state.
 - `all-the-icons': File icons provided by `all-the-icons.el'.
+- `emacs-nerd-icons': File icons provided by `emacs-nerd-icons.el'.
 - `vscode-icon': File icons provided by `vscode-icon.el'.
 - `collapse': Collapse unique nested paths.
 - `git-msg': Append git commit message to filename.
@@ -228,7 +229,7 @@ input for `dirvish-redisplay-debounce' seconds."
                       file-inode-number file-device-number
                       audio image gif video epub pdf pdf-preface archive)
     (dirvish-vc       vc-state git-msg vc-diff vc-blame vc-log vc-info)
-    (dirvish-icons    all-the-icons vscode-icon)
+    (dirvish-icons    all-the-icons emacs-nerd-icons vscode-icon)
     (dirvish-collapse collapse)
     (dirvish-subtree  subtree-state)
     (dirvish-yank     yank)))
@@ -1041,6 +1042,7 @@ LEVEL is the depth of current window."
         (attrs (append
                 '(hl-line symlink-target)
                 (cond ((memq 'all-the-icons dirvish-attributes) '(all-the-icons))
+                      ((memq 'emacs-nerd-icons dirvish-attributes) '(emacs-nerd-icons))
                       ((memq 'vscode-icon dirvish-attributes) '(vscode-icon))))))
     (with-current-buffer buf
       (dirvish-directory-view-mode)

--- a/extensions/dirvish-icons.el
+++ b/extensions/dirvish-icons.el
@@ -9,12 +9,14 @@
 
 ;;; Commentary:
 
-;; Integrate `all-the-icons' and `vscode-icon' with Dirvish.
+;; Integrate `all-the-icons', `emacs-nerd-icons' and `vscode-icon' with Dirvish.
 
 ;;; Code:
 
 (declare-function all-the-icons-icon-for-file "all-the-icons")
 (declare-function all-the-icons-icon-for-dir "all-the-icons")
+(declare-function emacs-nerd-icons-icon-for-file "emacs-nerd-icons")
+(declare-function emacs-nerd-icons-icon-for-dir "emacs-nerd-icons")
 (declare-function vscode-icon-can-scale-image-p "vscode-icon")
 (declare-function vscode-icon-file "vscode-icon")
 (declare-function vscode-icon-dir-exists-p "vscode-icon")
@@ -53,6 +55,25 @@ Values are interpreted as follows:
 - nil, inherit face at point."
   :group 'dirvish :type '(choice face symbol nil))
 
+(defcustom dirvish-emacs-nerd-icons-offset 0.00
+  "Icon's vertical offset used for `emacs-nerd-icons' backend.
+Set it to nil to use the default offset from `emacs-nerd-icons'."
+  :group 'dirvish :type '(choice (float nil)))
+
+(defcustom dirvish-emacs-nerd-icons-height nil
+  "Icon height used for `emacs-nerd-icons' backend.
+The height of the icon is scaled to this value (try 0.8).
+Set it to nil to use the default height from `emacs-nerd-icons'."
+  :group 'dirvish :type '(choice (float nil)))
+
+(defcustom dirvish-emacs-nerd-icons-palette 'emacs-nerd-icons
+  "Coloring style used for file `emacs-nerd-icons' backend.
+Values are interpreted as follows:
+- emacs-nerd-icons, meaning let `emacs-nerd-icons.el' to do the coloring.
+- A face that is used for all the icons.
+- nil, inherit face at point."
+  :group 'dirvish :type '(choice face symbol nil))
+
 (defcustom dirvish-vscode-icon-size 32
   "Icon (image pixel) size used for `vscode-icon' backend.
 The value should be a integer between 23 to 128."
@@ -70,6 +91,23 @@ The value should be a integer between 23 to 128."
          (icon (if (eq (car f-type) 'dir)
                    (apply #'all-the-icons-icon-for-dir f-name icon-attrs)
                  (apply #'all-the-icons-icon-for-file f-str icon-attrs)))
+         (icon-str (concat icon (propertize dirvish-icon-delimiter 'face hl-face)))
+         (ov (make-overlay (1- f-beg) f-beg)))
+    (overlay-put ov 'after-string icon-str)
+    `(ov . ,ov)))
+
+(dirvish-define-attribute emacs-nerd-icons
+  "File icons provided by `emacs-nerd-icons.el'."
+  :width (+ (length dirvish-icon-delimiter) 2)
+  (let* ((offset `(:v-adjust ,dirvish-emacs-nerd-icons-offset))
+         (height `(:height ,dirvish-emacs-nerd-icons-height))
+         (face (cond (hl-face `(:face ,hl-face))
+                     ((eq dirvish-emacs-nerd-icons-palette 'emacs-nerd-icons) nil)
+                     (t `(:face ,dirvish-emacs-nerd-icons-palette))))
+         (icon-attrs (append face offset height))
+         (icon (if (eq (car f-type) 'dir)
+                   (apply #'emacs-nerd-icons-icon-for-dir f-name icon-attrs)
+                 (apply #'emacs-nerd-icons-icon-for-file f-str icon-attrs)))
          (icon-str (concat icon (propertize dirvish-icon-delimiter 'face hl-face)))
          (ov (make-overlay (1- f-beg) f-beg)))
     (overlay-put ov 'after-string icon-str)

--- a/extensions/dirvish-subtree.el
+++ b/extensions/dirvish-subtree.el
@@ -15,6 +15,7 @@
 ;;; Code:
 
 (declare-function all-the-icons-octicon "all-the-icons")
+(declare-function emacs-nerd-icons-octicon "emacs-nerd-icons")
 (declare-function consult-lsp-file-symbols "consult-lsp")
 (declare-function consult-imenu "consult-imenu")
 (declare-function consult-line "consult")
@@ -47,11 +48,12 @@ The prefix is repeated \"depth\" times."
 (defvar dirvish-subtree--state-icons nil)
 (defcustom dirvish-subtree-state-style 'chevron
   "Icon/string used for directory expanded state.
-The value can be one of: `plus', `arrow', `chevron'."
+The value can be one of: `plus', `arrow', `chevron', `nerd'."
   :group 'dirvish :type 'symbol
   :set
   (lambda (k v)
     (and (eq v 'chevron) (not (require 'all-the-icons nil t)) (setq v 'arrow))
+    (and (eq v 'nerd) (not (require 'emacs-nerd-icons nil t)) (setq v 'arrow))
     (set k v)
     (setq dirvish-subtree--state-icons
           (pcase (symbol-value k)
@@ -59,6 +61,17 @@ The value can be one of: `plus', `arrow', `chevron'."
                          (propertize "+" 'face 'dirvish-subtree-state)))
             ('arrow (cons (propertize "▾" 'face 'dirvish-subtree-state)
                           (propertize "▸" 'face 'dirvish-subtree-state)))
+            ('nerd
+             (cons
+              (emacs-nerd-icons-octicon
+               "nf-oct-chevron_down"
+               :height (* (or (bound-and-true-p dirvish-emacs-nerd-icons-height) 1) 0.8)
+               :v-adjust 0.1 :face 'dirvish-subtree-state)
+              (emacs-nerd-icons-octicon
+               "nf-oct-chevron_right"
+               :height (* (or (bound-and-true-p dirvish-emacs-nerd-icons-height) 1) 0.8)
+               :v-adjust 0.1 :face 'dirvish-subtree-state)
+              ))
             ('chevron
              (cons
               (all-the-icons-octicon


### PR DESCRIPTION
Add support for [emacs-nerd-icons](https://github.com/rainstormstudio/emacs-nerd-icons).

Now icons can be displayed on both GUI and terminal.

on terminal (with Nerd Fonts installed):
![image](https://user-images.githubusercontent.com/22017420/229234297-e053b492-710c-438b-a487-bbda9a700276.png)

major configuration for emacs-nerd-icons:
```  elisp
(setq dirvish-attributes
      '(vc-state subtree-state emacs-nerd-icons collapse git-msg file-time file-size))
(setq dirvish-subtree-state-style 'nerd)
```

(note: I'm currently waiting for emacs-nerd-icons to be accepted on Melpa)

