### PR TITLE
fix(core): don't quote conditions in condition-case

### DIFF
--- a/dirvish-extras.el
+++ b/dirvish-extras.el
@@ -305,7 +305,7 @@ FILESET defaults to `dired-get-marked-files'."
                               (directory-files-recursively f ".*" nil t)))
               (f-size (f) (condition-case nil
                               (file-attribute-size (file-attributes f))
-                            ('file-error 0))))
+                            (file-error 0))))
     (let* ((fileset (or fileset (dired-get-marked-files)))
            (count (propertize (number-to-string (length fileset))
                               'face 'font-lock-builtin-face))

--- a/extensions/dirvish-subtree.el
+++ b/extensions/dirvish-subtree.el
@@ -358,8 +358,8 @@ See `dirvish-subtree-file-viewer' for details"
   (if (dirvish-subtree--expanded-p)
       (progn (dired-next-line 1) (dirvish-subtree-remove))
     (condition-case err (dirvish-subtree--insert)
-      ('file-error (dirvish-subtree--view-file))
-      ('error (message "%s" (cdr err))))))
+      (file-error (dirvish-subtree--view-file))
+      (error (message "%s" (cdr err))))))
 
 (defun dirvish-subtree-toggle-or-open (ev)
   "Toggle the subtree if in a dirline, otherwise open the file.


### PR DESCRIPTION
As the byte-compiler points out, these condition symbols should not be quoted.