### PR TITLE
Fix custom type specifications

### DIFF
--- a/dirvish.el
+++ b/dirvish.el
@@ -187,8 +187,8 @@ and its ARGS is issued to open the file externally.  The special
 placeholder \"%f\" in the ARGS is replaced by the FILENAME at
 runtime.  Set it to nil disables this feature."
   :group 'dirvish
-  :type '(alist :key-type ((repeat string) :tag "File extensions")
-                :value-type ((repeat string) :tag "External command and args")))
+  :type '(alist :key-type (repeat :tag "File extensions" string)
+                :value-type (repeat :tag "External command and args" string)))
 
 (defcustom dirvish-reuse-session t
   "Whether to reuse the hidden sessions.

--- a/dirvish.el
+++ b/dirvish.el
@@ -121,11 +121,11 @@ and H-FRAME represent the height of mode line in single window
 state and fullframe state respectively.  If this value is a
 integer INT, it is seen as a shorthand for (INT . INT)."
   :group 'dirvish
-  :type '(choice interger (cons integer integer)))
+  :type '(choice integer (cons integer integer)))
 
 (defcustom dirvish-header-line-height 30
   "Like `dirvish-mode-line-height', but for header line."
-  :type '(choice interger (cons integer integer)))
+  :type '(choice integer (cons integer integer)))
 
 (defcustom dirvish-mode-line-format
   '(:left (sort omit symlink) :right (index))

--- a/dirvish.el
+++ b/dirvish.el
@@ -262,7 +262,7 @@ input for `dirvish-redisplay-debounce' seconds."
 ;;;; Macros
 
 (defmacro dirvish-prop (prop &rest body)
-  "Retrive PROP from `dirvish--props'.
+  "Retrieve PROP from `dirvish--props'.
 Set the PROP with BODY if given."
   (declare (indent defun))
   `(let* ((pair (assq ,prop dirvish--props)) (val (cdr pair)))

--- a/dirvish.el
+++ b/dirvish.el
@@ -939,10 +939,10 @@ If HEADER, set the `dirvish--header-line-fmt' instead."
                            `(:eval (,(intern (format "dirvish-%s-ml" s)) (dirvish-curr))))))
               (get-font-scale ()
                 (let* ((face (if header 'header-line 'mode-line-inactive))
-                       (defualt (face-attribute 'default :height))
+                       (default (face-attribute 'default :height))
                        (ml-height (face-attribute face :height)))
                   (cond ((floatp ml-height) ml-height)
-                        ((integerp ml-height) (/ (float ml-height) defualt))
+                        ((integerp ml-height) (/ (float ml-height) default))
                         (t 1)))))
     `((:eval
        (let* ((dv (dirvish-curr))

--- a/docs/CHANGELOG.org
+++ b/docs/CHANGELOG.org
@@ -173,7 +173,7 @@ even outperforms Dired in terms of opening big directories.
 + =extras=: add ~dirvish-switch-layout~ command ([[https://github.com/alexluigit/dirvish/issues/33][#33]])
 + =core=: add symlink mode line ([[https://github.com/alexluigit/dirvish/issues/41][#41]])
 + =extras=: make ~file-size~ files count in directories ([[https://github.com/alexluigit/dirvish/issues/40][#40]])
-+ =core=: add ~dirvish-dwim~ commmand
++ =core=: add ~dirvish-dwim~ command
 + =core=: add auto cache facility ([[https://github.com/alexluigit/dirvish/issues/28][#28]])
 + =extras=: add ~dirvish-go-forward/backward-history~ cmds ([[https://github.com/alexluigit/dirvish/issues/32][#32]])
 + =yank=: add ~dirvish-yank-overwrite-existing-files~ option ([[https://github.com/alexluigit/dirvish/issues/38][#38]])
@@ -195,7 +195,7 @@ even outperforms Dired in terms of opening big directories.
 + =core=: remove builtin attributes from dirvish--available-attrs
 + =core=: remove redundant session initialization
 + =core=: find-dired mode-line segment
-+ =core=: retrive path for auto cache correctly
++ =core=: retrieve path for auto cache correctly
 + =extras=: file permission error
 + =yank=: remote-to-remote handler
 + =core=: preserve size of header window when showing transient
@@ -245,7 +245,7 @@ even outperforms Dired in terms of opening big directories.
 + =side=: keep the side window alive on =delete-other-windows=
 + =core=: avoid void session error on window quit
 + =core=: error at initialization when ~dired-hide-details-mode~ is turned off
-+ =core=: ensure retriving dwim-target from live window
++ =core=: ensure retrieving dwim-target from live window
 + =core=: hide cursor in utility buffers
 
 * 1.0.0

--- a/docs/CHANGELOG.org
+++ b/docs/CHANGELOG.org
@@ -89,7 +89,7 @@
 
 ** Changes since 1.8.14
 
-+ =ls=: apply switches to current session on M-RET ([[https://github.com/alexluigit/dirvish/issus/63][#63]])
++ =ls=: apply switches to current session on M-RET ([[https://github.com/alexluigit/dirvish/issues/63][#63]])
 + =narrow=: C-g to cancel the narrowing / custom regex builder
 + =emerge=:
   - Add ~dirvish-emerge-toggle-current-group~ command to to toggle the visibility of the group
@@ -101,23 +101,23 @@
 
 + =core=:
   - revert to `dirvish-mode` after quit `wdired-mode`
-  - guard `dired-current-directory` in dwim target ([[https://github.com/alexluigit/dirvish/issus/78][#78]])
+  - guard `dired-current-directory` in dwim target ([[https://github.com/alexluigit/dirvish/issues/78][#78]])
   - scroll preview util buffer with `scroll-other-window`
   - set buffer-modified-p to nil at startup
   - kill session util buffers on dirvish-kill-buffer-h
   - rename obsolete command in `dirvish-dispatch`
   - highlight current line in any case
-  - reuse fullscreen sessions unconditionally ([[https://github.com/alexluigit/dirvish/issus/64][#64]])
-  - kill overlapping session correctly ([[https://github.com/alexluigit/dirvish/issus/64][#64]])
+  - reuse fullscreen sessions unconditionally ([[https://github.com/alexluigit/dirvish/issues/64][#64]])
+  - kill overlapping session correctly ([[https://github.com/alexluigit/dirvish/issues/64][#64]])
 + =emerge=:
   - apply changes in transient menu to buffer
   - infinite while loop
   - expunge invisible overlay property
 + =subtree=: revert subtrees after emerging groups
-+ =extras=: increase file size string length to 8 ([[https://github.com/alexluigit/dirvish/issus/77][#77]])
-+ =peek=: get candidate retriever at runtime ([[https://github.com/alexluigit/dirvish/issus/70][#70]])
-+ =bookmark=: void variable error ([[https://github.com/alexluigit/dirvish/issus/75][#75]])
-+ =narrow=: drop the overlay approach, accommodate subtree ([[https://github.com/alexluigit/dirvish/issus/67][#67]])
++ =extras=: increase file size string length to 8 ([[https://github.com/alexluigit/dirvish/issues/77][#77]])
++ =peek=: get candidate retriever at runtime ([[https://github.com/alexluigit/dirvish/issues/70][#70]])
++ =bookmark=: void variable error ([[https://github.com/alexluigit/dirvish/issues/75][#75]])
++ =narrow=: drop the overlay approach, accommodate subtree ([[https://github.com/alexluigit/dirvish/issues/67][#67]])
 
 * 1.8.14
 ** Breaking changes

--- a/docs/COMPARISON.org
+++ b/docs/COMPARISON.org
@@ -38,7 +38,7 @@ See this [[https://github.com/alexluigit/dirvish/issues/10][discussion]].
 * all-the-icons-dired
 
 I'd advise *against* using this package ([[https://github.com/jtbm37/all-the-icons-dired][all-the-icons-dired]]) along with
-Dirvish. The reason is that it trys to retrive icons for all the files in a
+Dirvish. The reason is that it tries to retrieve icons for all the files in a
 directory /eagerly/, which hangs up Emacs on large directories. Dirvish, on the
 contrary, renders UI elements (including icons of course) *lazily* whenever
 applicable.
@@ -53,7 +53,7 @@ columns in Dirvish on =spacemacs=. A workaround can be found [[https://github.co
 ** dired-ranger
 
 The ~dirvish-yank/move~ command can do similar things as ~dired-ranger-move/paste~,
-meanwhile, it has serveral benefits over ~dired-do-copy~ or ~dired-ranger~:
+meanwhile, it has several benefits over ~dired-do-copy~ or ~dired-ranger~:
 
 - It paste/move files using external processes, hence heavy I/O tasks won't
   block the main process of Emacs.
@@ -78,7 +78,7 @@ Comparing with =dired-subtree=, =dirvish-subtree= has several advantages:
    Dirvish has no plan on implementing the =ibuffer= like "filter-stack" because
    IMO the Dired marking system plus different ~dired-listing-switches~ covers
    almost all the possible file filtering needs.  In terms of filtering files
-   matching multiple criterias, you can always mark files using various
+   matching multiple criteria, you can always mark files using various
    ~dired-mark-*~ commands and kill the rest lines.  This also makes
    ~dirvish-emerge.el~ a relatively small codebase.
 

--- a/docs/CUSTOMIZING.org
+++ b/docs/CUSTOMIZING.org
@@ -189,7 +189,7 @@ want to display preview for epub files via packages like =nov=, just remove the
 #+end_src
 
 Some of preview dispatchers, such as ~image~, generate cache images to improve the
-preview experience.  Everytime you enter a directory, Dirvish scans the the
+preview experience.  Every time you enter a directory, Dirvish scans the the
 content of that directory and computes the fileset of the directory that
 requires cache image generation, the corresponding caches are generated later
 when Emacs is idle.
@@ -353,7 +353,7 @@ These packages are only listed here for discoverability.
     (setq dired-omit-files
           (concat dired-omit-files "\\|^\\..*$")))
 
-  ;; Addtional syntax highlighting for dired
+  ;; Additional syntax highlighting for dired
   (use-package diredfl
     :hook
     ((dired-mode . diredfl-mode)

--- a/docs/EXTENSIONS.org
+++ b/docs/EXTENSIONS.org
@@ -50,7 +50,7 @@ This extension lets you split the file list into different groups by various
 criteria.  These groups are then displayed in the same manner as ~ibuffer~.
 
 The variable ~dirvish-emerge-groups~ contains filter criteria of groups.
-Althought you can set this variable globally, a more appropriate way would be
+Although you can set this variable globally, a more appropriate way would be
 set it directory locally.  In that case, it is recommended to compose and save
 this variable to .dir-locals.el by the help of ~dirvish-emerge-menu~, which saves
 the manual editing.

--- a/extensions/dirvish-emerge.el
+++ b/extensions/dirvish-emerge.el
@@ -51,7 +51,7 @@ in the buffer are separated and rearranged by the following groups:
 4. files whose extension is \"tex\" or \"bib\"
 5. other files
 
-Althought you can set this variable globally, a more appropriate
+Although you can set this variable globally, a more appropriate
 way would be set it directory locally.  In that case, it is
 recommended to compose and save this variable to .dir-locals.el
 by the help of `dirvish-emerge-menu'."
@@ -117,7 +117,7 @@ turned on in the buffer."
 
 (defmacro dirvish-emerge-define-predicate (name docstring &rest body)
   "Define a group predicate NAME with BODY.
-DOCSTRING is the documention of the predicate.
+DOCSTRING is the documentation of the predicate.
 The predicate takes the following arguments:
 
 - `local-name': output from (file-name-nondirectory FILE)

--- a/extensions/dirvish-icons.el
+++ b/extensions/dirvish-icons.el
@@ -53,18 +53,18 @@ Values are interpreted as follows:
 - all-the-icons, meaning let `all-the-icons.el' to do the coloring.
 - A face that is used for all the icons.
 - nil, inherit face at point."
-  :group 'dirvish :type '(choice face symbol nil))
+  :group 'dirvish :type '(choice face symbol (const nil)))
 
 (defcustom dirvish-nerd-icons-offset 0.00
   "Icon's vertical offset used for `nerd-icons' backend.
 Set it to nil to use the default offset from `nerd-icons'."
-  :group 'dirvish :type '(choice (float nil)))
+  :group 'dirvish :type '(choice float (const nil)))
 
 (defcustom dirvish-nerd-icons-height nil
   "Icon height used for `nerd-icons' backend.
 The height of the icon is scaled to this value (try 0.8).
 Set it to nil to use the default height from `nerd-icons'."
-  :group 'dirvish :type '(choice (float nil)))
+  :group 'dirvish :type '(choice float (const nil)))
 
 (defcustom dirvish-nerd-icons-palette 'nerd-icons
   "Coloring style used for file `nerd-icons' backend.
@@ -72,7 +72,7 @@ Values are interpreted as follows:
 - nerd-icons, meaning let `nerd-icons.el' to do the coloring.
 - A face that is used for all the icons.
 - nil, inherit face at point."
-  :group 'dirvish :type '(choice face symbol nil))
+  :group 'dirvish :type '(choice face symbol (const nil)))
 
 (defcustom dirvish-vscode-icon-size 32
   "Icon (image pixel) size used for `vscode-icon' backend.

--- a/extensions/dirvish-ls.el
+++ b/extensions/dirvish-ls.el
@@ -159,7 +159,7 @@ invoke the sort function, SWITCHES is the the sort flags for
     ""
     "toggles"
     ("r" "Reverse order while sorting" "--reverse")
-    ("d" "List directories ontop" "--group-directories-first")
+    ("d" "List directories on top" "--group-directories-first")
     ("~" "Hide backups files (eg. foo~)" "--ignore-backups")
     ("A" "Show the author" "--author")
     ("C" "Show security context" "--context")

--- a/extensions/dirvish-peek.el
+++ b/extensions/dirvish-peek.el
@@ -27,11 +27,11 @@
 If this value is nil, a candidate fetcher function is
 automatically choosed according to your completion framework
 being used at runtime."
-  :group 'dirvish :type '(choice function nil))
+  :group 'dirvish :type '(choice function (const nil)))
 
 (defcustom dirvish-peek-categories '(file project-file library)
   "Minibuffer metadata categories to show file preview."
-  :group 'dirvish :type 'list)
+  :group 'dirvish :type '(repeat symbol))
 
 (defvar dirvish-peek--cand-fetcher nil)
 (defun dirvish-peek--prepare-cand-fetcher ()

--- a/extensions/dirvish-subtree.el
+++ b/extensions/dirvish-subtree.el
@@ -375,7 +375,7 @@ See `dirvish-subtree-file-viewer' for details"
 
 (defun dirvish-subtree-toggle-or-open (ev)
   "Toggle the subtree if in a dirline, otherwise open the file.
-This command takes a mouse event EV as its argment."
+This command takes a mouse event EV as its argument."
   (interactive "e")
   (let ((win (posn-window (event-end ev)))
         (pos (posn-point (event-end ev))))

--- a/extensions/dirvish-vc.el
+++ b/extensions/dirvish-vc.el
@@ -37,7 +37,7 @@ This value is consumed by `vc-state' attribute in Dirvish.  FACE
 is the face used for that VC-STATE.  See `vc-state' in (in
 vc-hooks.el) for detail explanation of these states."
   :group 'dirvish
-  :type '(alist :key-type symbol :value-type '(symbol :tag "Face")))
+  :type '(alist :key-type symbol :value-type (symbol :tag "Face")))
 
 (defface dirvish-vc-needs-merge-face
   '((((background dark)) (:background "#500f29"))

--- a/extensions/dirvish-yank.el
+++ b/extensions/dirvish-yank.el
@@ -524,7 +524,7 @@ unexpected errors."
   "Select init values from the local session or emacs session or saved transient values."
   (if-let ((session-switches (dirvish-prop :rsync-switches)))
       session-switches
-    ;; dont touch if it is alreday set
+    ;; dont touch if it is already set
     (if (slot-boundp obj 'value)
         (oref obj value)
       ;; check saved values

--- a/extensions/dirvish-yank.el
+++ b/extensions/dirvish-yank.el
@@ -65,7 +65,7 @@ The value can be a symbol or a function that returns a fileset."
 
 (defcustom dirvish-yank-rsync-args '("--archive" "--verbose" "--compress" "--info=progress2")
   "The default options for the rsync command."
-  :type 'list :group 'dirvish)
+  :type '(repeat string) :group 'dirvish)
 
 (defcustom dirvish-yank-keep-success-log t
   "If non-nil then keep logs of all completed yanks.

--- a/extensions/dirvish-yank.el
+++ b/extensions/dirvish-yank.el
@@ -521,7 +521,9 @@ unexpected errors."
      (t (dirvish-yank-l2fr-handler srcs dest)))))
 
 (defun dirvish-yank--rsync-transient-init-value (obj)
-  "Select init values from the local session or emacs session or saved transient values."
+  "Select initial values for transient suffixes.
+Use values from the local session or emacs session or saved transient
+values."
   (if-let ((session-switches (dirvish-prop :rsync-switches)))
       session-switches
     ;; dont touch if it is already set

--- a/extensions/dirvish-yank.el
+++ b/extensions/dirvish-yank.el
@@ -583,6 +583,8 @@ unexpected errors."
   ["Action"
    [("RET" "Apply switches and copy" dirvish-yank--rsync-apply-switches-and-copy)]])
 
+(defvar crm-separator)
+
 (defun dirvish-yank--rsync-transient-read-multiple (prompt &optional _initial-input history)
   "Read multiple values after PROMPT with optional INITIAL_INPUT and HISTORY."
   (let ((crm-separator ","))


### PR DESCRIPTION
On Emacs' "master" branch, the byte-compiler recently learned to recognize more common mistakes in custom type specifications.  This pull-requests fixes most of them, but there are two exceptions, you still have to find a solution for:

```
lib/dirvish/dirvish.el:190:29: Warning: in defcustom for ‘dirvish-open-with-programs’: irregular type ‘(repeat string)’
lib/dirvish/dirvish.el:191:31: Warning: in defcustom for ‘dirvish-open-with-programs’: irregular type ‘(repeat string)’
```

This pr also includes the commits from my earlier prs, #220 and #227.