### PR TITLE
fix(dired-noselect): Support both lists and strings

### DIFF
--- a/dirvish.el
+++ b/dirvish.el
@@ -676,9 +676,10 @@ buffer, it defaults to filename under the cursor when it is nil."
                           (with-current-buffer buf (dirvish--render-attrs)))))))
     (with-current-buffer buf (add-hook 'post-command-hook fun nil t)) buf))
 
-(defun dirvish-dired-noselect-a (fn dir &optional flags)
+(defun dirvish-dired-noselect-a (fn dir-or-list &optional flags)
   "Return buffer for DIR with FLAGS, FN is `dired-noselect'."
-  (let* ((key (file-name-as-directory (expand-file-name dir)))
+  (let* ((dir (if (consp dir-or-list) (car dir-or-list) dir-or-list))
+         (key (file-name-as-directory (expand-file-name dir)))
          (this dirvish--this)
          (dv (if (and this (eq this-command 'dired-other-frame)) (dirvish-new)
                (or this (car (dirvish--find-reusable)) (dirvish-new))))
@@ -691,9 +692,9 @@ buffer, it defaults to filename under the cursor when it is nil."
     (when new-buffer-p
       (if (not remote)
           (let ((dired-buffers nil)) ; disable reuse from dired
-            (setq buffer (apply fn (list dir flags))))
+            (setq buffer (apply fn (list dir-or-list flags))))
         (require 'dirvish-extras)
-        (setq buffer (dirvish-noselect-tramp fn dir flags remote)))
+        (setq buffer (dirvish-noselect-tramp fn dir-or-list flags remote)))
       (with-current-buffer buffer (dirvish-init-dired-buffer))
       (push (cons key buffer) (dv-roots dv))
       (push (cons key buffer) dired-buffers))
@@ -702,8 +703,8 @@ buffer, it defaults to filename under the cursor when it is nil."
             ((and (not remote) (not (equal flags dired-actual-switches)))
              (dired-sort-other flags))
             ((eq dired-auto-revert-buffer t) (revert-buffer))
-	    ((functionp dired-auto-revert-buffer)
-	     (when (funcall dired-auto-revert-buffer dir) (revert-buffer))))
+            ((functionp dired-auto-revert-buffer)
+             (when (funcall dired-auto-revert-buffer dir) (revert-buffer))))
       (dirvish-prop :dv (dv-name dv))
       (dirvish-prop :gui (display-graphic-p))
       (dirvish-prop :remote remote)


### PR DESCRIPTION
Dired supports both strings and lists in dired-noselect.

``` elisp
(defun dired-noselect (dir-or-list &optional switches)
  "Like `dired' but return the Dired buffer as value, do not select it."
  (or dir-or-list (setq dir-or-list default-directory))
  ;; This loses the distinction between "/foo/*/" and "/foo/*" that
  ;; some shells make:
  (let (dirname initially-was-dirname)
    (if (consp dir-or-list)
	(setq dirname (car dir-or-list))
      (setq dirname dir-or-list))
    (setq initially-was-dirname
	  (string= (file-name-as-directory dirname) dirname))
    (setq dirname (abbreviate-file-name
		   (expand-file-name (directory-file-name dirname))))
    (if find-file-visit-truename
	(setq dirname (file-truename dirname)))
    ;; If the argument was syntactically  a directory name not a file name,
    ;; or if it happens to name a file that is a directory,
    ;; convert it syntactically to a directory name.
    ;; The reason for checking initially-was-dirname
    ;; and not just file-directory-p
    ;; is that file-directory-p is slow over ftp.
    (if (or initially-was-dirname (file-directory-p dirname))
	(setq dirname  (file-name-as-directory dirname)))
    (if (consp dir-or-list)
	(setq dir-or-list (cons dirname (cdr dir-or-list)))
      (setq dir-or-list dirname))
    (dired-internal-noselect dir-or-list switches)))
```

```
GNU Emacs 29.2 (build 1, aarch64-apple-darwin23.2.0, NS appkit-2487.30 Version 14.2.1 (Build 23C71))
```

https://github.com/oantolin/embark/issues/701