### PR TITLE
Remove the restriction on printing for `dirvish-data-for-dir`

### DIFF
--- a/dirvish.el
+++ b/dirvish.el
@@ -1153,6 +1153,8 @@ LEVEL is the depth of current window."
   "Fetch data for files in DIR, stored locally in BUFFER.
 Run `dirvish-setup-hook' afterwards when SETUP is non-nil."
   (let* ((buf (make-temp-name "dir-data-"))
+         (print-length nil)
+         (print-level nil)
          (c (format "%S" `(message "%s" ,(dirvish--dir-data-getter dir))))
          (proc (make-process :name "dir-data" :connection-type nil :buffer buf
                              :command (list dirvish-emacs-bin "-Q" "-batch" "--eval" c)


### PR DESCRIPTION
The line

```elisp
(format "%S" `(message "%s" ,(dirvish--dir-data-getter dir)))
```

Sometimes generates something like:

```elisp
(with-temp-buffer (let ((hash ...) (bk ...)) (dolist (file ...) (let* ... ... ...)) (prin1 (cons bk hash) (current-buffer))) (buffer-substring-no-properties (point-min) (point-max)))
```

which is then sent to `emacs -Q` to run but of course it fails to run because of the ellipses all over the code. These ellipses are managed by `print-length` and `print-level` variables which are when set to `nil` never generates ellipses.

Possibly we need to set these variables to `nil` whenever we generate code using `(format "%S")` but I haven't had any problems with other parts so far.