### PR TITLE
fix(subtree): "toggle or open" should open file, not view it

### DIFF
--- a/extensions/dirvish-subtree.el
+++ b/extensions/dirvish-subtree.el
@@ -383,9 +383,10 @@ This command takes a mouse event EV as its argment."
     (select-window win)
     (with-current-buffer (window-buffer win)
       (goto-char pos)
-      (condition-case nil
-          (dirvish-subtree-toggle)
-        (error (dirvish-find-entry-a (dired-get-file-for-visit)))))
+      (when-let ((entry (dired-get-filename nil t)))
+        (if (file-directory-p entry)
+            (dirvish-subtree-toggle)
+          (dirvish-find-entry-a entry))))
     (when (window-live-p win) (select-window win))))
 
 ;;;###autoload (autoload 'dirvish-subtree-menu "dirvish-subtree" nil t)


### PR DESCRIPTION
Currently, `dirvish-subtree-toggle-or-open` utilizes `dirvish-subtree-toggle` to first attempt to toggle a directory line, then if that fails it assumes the current line represents a file and will attempt to open the file.  Unfortunately,
`dirvish-subtree-toggle` has an error handler, so if the directory toggle does fail it will view the file and not propagate the error. Since an error handler prevents the propagation of a directory toggle failure up to `dirvish-subtree-toggle-or-open`, the result is that when the current line represents a file, it will always be viewed instead of opened.

Instead of depending on error propagation when the line is not a directory, this change instead checks to see if the line represents a directory first.  When it is a directory, `dirvish-subtree-toggle` is called to handle the directory, otherwise the file is opened.