### PR TITLE
fix: require dirvish-extras for dirvish-ls-output-parser

### DIFF
--- a/dirvish-tramp.el
+++ b/dirvish-tramp.el
@@ -16,6 +16,7 @@
 ;;; Code:
 
 (require 'dirvish)
+(require 'dirvish-extras)
 (require 'tramp)
 
 (defconst dirvish-tramp-preview-cmd


### PR DESCRIPTION
Fix for bea294543ed8f714836e1a102a06fbda09916250.