### PR TITLE
fix(tramp): support gvfs

### DIFF
--- a/dirvish-tramp.el
+++ b/dirvish-tramp.el
@@ -27,11 +27,11 @@
 Save the REMOTE host to `dirvish-tramp-hosts'.
 FN is the original `dired-noselect' closure."
   (let* ((saved-flags (cdr (assoc remote dirvish-tramp-hosts #'equal)))
-         (ftp? (tramp-ftp-file-name-p dir))
+         (doesnt-support-ls? (or (tramp-ftp-file-name-p dir) (tramp-gvfs-file-name-p dir)))
          (short-flags "-Alh")
          (default-directory dir)
          (dired-buffers nil)
-         (buffer (cond (ftp? (funcall fn dir short-flags))
+         (buffer (cond (doesnt-support-ls? (funcall fn dir short-flags))
                        (saved-flags (funcall fn dir saved-flags))
                        ((= (process-file "ls" nil nil nil "--version") 0)
                         (push (cons remote flags) dirvish-tramp-hosts)


### PR DESCRIPTION
Both `ftp `and `gvfs` (e.g. used for connecting with Nextcloud) don't support `(process-file "ls" ...)` (it evaluates to `nil`) - this commit adjusts Dirvish so that it knows it and doesn't try to `(process-file "ls ...)` for both of those protocols.

N.B. this feels somewhat brittle - maybe instead of having explicit `if ftp or gvfs`, we could just run `ls` and check whether it evaluates to `nil`? 