### PR TITLE
feat(side): Add Commands for Manual Width Resizing

### DIFF
--- a/docs/EXTENSIONS.org
+++ b/docs/EXTENSIONS.org
@@ -190,6 +190,8 @@ as a sidebar in the frame.  These customization options are available:
 + ~dirvish-side-display-alist~: Display actions for the side window.
 + ~dirvish-side-window-parameters~: Window parameters for the side window.
 + ~dirvish-side-width~: Width of the side window.
++ ~dirvish-side-increase-width~: Increases the width of the side window by a set increment.
++ ~dirvish-side-decrease-width~: Decreases the width of the side window by a set increment.
 + ~dirvish-side-open-file-action~: Action to perform before opening a file in a side window.
 + ~dirvish-side-auto-expand~: Whether to auto expand parent directories of current file.
 

--- a/docs/EXTENSIONS.org
+++ b/docs/EXTENSIONS.org
@@ -181,8 +181,16 @@ To tweak the appearance of the icons, you have these options:
 
 * Toggle Dirvish in side window (dirvish-side.el)
 
-This extension provides the ~dirvish-side~ command. It toggles a Dirvish session
-as a sidebar in the frame.  These customization options are available:
+This extension provides the ~dirvish-side~ command, which toggles a Dirvish
+sidebar within the current frame.  The width is fixed to prevent the window from
+unexpected resizing, but you can adjust it using the ~dirvish-side-increase-width~
+and ~dirvish-side-decrease-width~ commands.
+
+When ~dirvish-side-follow-mode~ is enabled, the visible side session will select
+the current buffer's filename, similar to ~treemacs-follow-mode~ in =treemacs=. It
+will also visits the latest ~project-root~ after switching to a new project.
+
+These customization options are available:
 
 + ~dirvish-side-attributes~: like ~dirvish-attributes~, but for side window.
 + ~dirvish-side-mode-line-format~: like ~dirvish-mode-line-format~, but for side window.
@@ -190,14 +198,8 @@ as a sidebar in the frame.  These customization options are available:
 + ~dirvish-side-display-alist~: Display actions for the side window.
 + ~dirvish-side-window-parameters~: Window parameters for the side window.
 + ~dirvish-side-width~: Width of the side window.
-+ ~dirvish-side-increase-width~: Increases the width of the side window by a set increment.
-+ ~dirvish-side-decrease-width~: Decreases the width of the side window by a set increment.
 + ~dirvish-side-open-file-action~: Action to perform before opening a file in a side window.
 + ~dirvish-side-auto-expand~: Whether to auto expand parent directories of current file.
-
-When ~dirvish-side-follow-mode~ is enabled, the visible side session will select
-the current buffer's filename, similar to ~treemacs-follow-mode~ in =treemacs=. It
-will also visits the latest ~project-root~ after switching to a new project.
 
 * Setup ls switches on the fly (dirvish-ls.el)
 

--- a/extensions/dirvish-side.el
+++ b/extensions/dirvish-side.el
@@ -23,7 +23,7 @@
   "Width of the `dirvish-side' buffer."
   :type 'integer :group 'dirvish)
 
-(defcustom dirvish-side-width-increment 2
+(defcustom dirvish-side-width-increment 1
   "Amount to change width by when resizing `dirvish-side' window."
   :type 'integer :group 'dirvish)
 

--- a/extensions/dirvish-side.el
+++ b/extensions/dirvish-side.el
@@ -194,7 +194,6 @@ otherwise it defaults to `project-current'."
           (visible (select-window visible))
           (t (dirvish-side--new path)))))
 
-;;;###autoload
 (defun dirvish-side-increase-width ()
   "Increase width of the `dirvish-side' window."
   (interactive)
@@ -205,7 +204,6 @@ otherwise it defaults to `project-current'."
           (enlarge-window-horizontally dirvish-side-width-increment)))
     (user-error "No visible dirvish-side window found")))
 
-;;;###autoload
 (defun dirvish-side-decrease-width ()
   "Decrease width of the `dirvish-side' window."
   (interactive)

--- a/extensions/dirvish-side.el
+++ b/extensions/dirvish-side.el
@@ -23,7 +23,7 @@
   "Width of the `dirvish-side' buffer."
   :type 'integer :group 'dirvish)
 
-(defcustom dirvish-side-width-increment 5
+(defcustom dirvish-side-width-increment 2
   "Amount to change width by when resizing `dirvish-side' window."
   :type 'integer :group 'dirvish)
 


### PR DESCRIPTION
This PR addresses the inability to manually resize the `dirvish-side` window (#332) due to its `window-size-fixed` property. It introduces dedicated interactive commands that allow users to increase or decrease the side window's width on demand without permanently changing the `dirvish-side-width` setting or disrupting the fixed-size behavior during automatic window management.

