### PR TITLE
fix(tramp): don't call process-file for non-async connections

### DIFF
--- a/dirvish-tramp.el
+++ b/dirvish-tramp.el
@@ -35,7 +35,7 @@ FN is the original `dired-noselect' closure."
          (gnuls "ls")
          (buffer (cond ((eq async-type 'local) (funcall fn dir flags))
                        (saved-flags (funcall fn dir saved-flags)) ; skip
-                       ((= (process-file gnuls nil nil nil "--version") 0)
+                       ((= (or (process-file gnuls nil nil nil "--version") 1) 0)
                         (push (cons remote flags) dirvish-tramp-hosts)
                         (funcall fn dir flags))
                        (t (setq gnuls nil)


### PR DESCRIPTION
Hi!

Even though https://github.com/alexluigit/dirvish/pull/300 got closed, GVFS connections remain broken on my machine (`Wrong type argument: number-or-marker-p, nil`) - that's because calling `process-file` on those connections returns `nil`, and `(= nil 0)` ends up throwing this `Wrong type argument` error.

A simple solution is to coalesce `nil` into something else, e.g. `1`, simulating the command returning an error code.