### PR TITLE
fix: sometimes data is Source, and (cdr data) is invalid operation.

### DIFF
--- a/dirvish.el
+++ b/dirvish.el
@@ -1251,7 +1251,8 @@ INHIBIT-SETUP is passed to `dirvish-data-for-dir'."
        (condition-case err
            (setq data (with-current-buffer pb (read (buffer-string))))
          (error (message "Fetch dir data failed with error: %s" err)))
-       (when (buffer-live-p buf)
+       (when (and (buffer-live-p buf)
+                  (listp data))
          (with-current-buffer buf
            (when-let* ((attrs (cdr data)) ((hash-table-p attrs)))
              (maphash (lambda (k v) (puthash k v dirvish--dir-data)) attrs))


### PR DESCRIPTION
Backtrace:

```
Debugger entered--Lisp error: (wrong-type-argument listp Source)
  cdr(Source)
  (and t (cdr data))
  (let* ((attrs (and t (cdr data))) (s (and attrs (hash-table-p attrs)))) (if s (maphash #'(lambda (k v) (puthash k v dirvish--dir-data)) attrs)))
  (save-current-buffer (set-buffer buf) (let* ((attrs (and t (cdr data))) (s (and attrs (hash-table-p attrs)))) (if s (maphash #'(lambda (k v) (puthash k v dirvish--dir-data)) attrs))) (let* ((pair (assq :vc-backend dirvish--props)) (val (cdr pair))) (prog1 (setq val (or (car data) 0)) (if pair (setcdr (assq :vc-backend dirvish--props) val) (setq dirvish--props (cons (cons :vc-backend val) dirvish--props))))) (dirvish-data-for-dir dir buf inhibit-setup))
  (progn (save-current-buffer (set-buffer buf) (let* ((attrs (and t (cdr data))) (s (and attrs (hash-table-p attrs)))) (if s (maphash #'(lambda (k v) (puthash k v dirvish--dir-data)) attrs))) (let* ((pair (assq :vc-backend dirvish--props)) (val (cdr pair))) (prog1 (setq val (or (car data) 0)) (if pair (setcdr (assq :vc-backend dirvish--props) val) (setq dirvish--props (cons (cons :vc-backend val) dirvish--props))))) (dirvish-data-for-dir dir buf inhibit-setup)))
  (if (buffer-live-p buf) (progn (save-current-buffer (set-buffer buf) (let* ((attrs (and t (cdr data))) (s (and attrs (hash-table-p attrs)))) (if s (maphash #'(lambda ... ...) attrs))) (let* ((pair (assq :vc-backend dirvish--props)) (val (cdr pair))) (prog1 (setq val (or (car data) 0)) (if pair (setcdr (assq :vc-backend dirvish--props) val) (setq dirvish--props (cons ... dirvish--props))))) (dirvish-data-for-dir dir buf inhibit-setup))))
  (progn (condition-case err (setq data (save-current-buffer (set-buffer pb) (read (buffer-string)))) (error (message "Fetch dir data failed with error: %s" err))) (if (buffer-live-p buf) (progn (save-current-buffer (set-buffer buf) (let* ((attrs (and t ...)) (s (and attrs ...))) (if s (maphash #'... attrs))) (let* ((pair (assq :vc-backend dirvish--props)) (val (cdr pair))) (prog1 (setq val (or ... 0)) (if pair (setcdr ... val) (setq dirvish--props ...)))) (dirvish-data-for-dir dir buf inhibit-setup)))))
  (let ((buf x525) (inhibit-setup x526)) (progn (condition-case err (setq data (save-current-buffer (set-buffer pb) (read (buffer-string)))) (error (message "Fetch dir data failed with error: %s" err))) (if (buffer-live-p buf) (progn (save-current-buffer (set-buffer buf) (let* ((attrs ...) (s ...)) (if s (maphash ... attrs))) (let* ((pair ...) (val ...)) (prog1 (setq val ...) (if pair ... ...))) (dirvish-data-for-dir dir buf inhibit-setup))))))
  (let* ((x525 (car-safe x0)) (x526 (cdr-safe x0))) (let ((buf x525) (inhibit-setup x526)) (progn (condition-case err (setq data (save-current-buffer (set-buffer pb) (read (buffer-string)))) (error (message "Fetch dir data failed with error: %s" err))) (if (buffer-live-p buf) (progn (save-current-buffer (set-buffer buf) (let* (... ...) (if s ...)) (let* (... ...) (prog1 ... ...)) (dirvish-data-for-dir dir buf inhibit-setup)))))))
  (progn (ignore (consp x0)) (let* ((x525 (car-safe x0)) (x526 (cdr-safe x0))) (let ((buf x525) (inhibit-setup x526)) (progn (condition-case err (setq data (save-current-buffer (set-buffer pb) (read ...))) (error (message "Fetch dir data failed with error: %s" err))) (if (buffer-live-p buf) (progn (save-current-buffer (set-buffer buf) (let* ... ...) (let* ... ...) (dirvish-data-for-dir dir buf inhibit-setup))))))))
  (let ((pb x527) (data x528)) (progn (ignore (consp x0)) (let* ((x525 (car-safe x0)) (x526 (cdr-safe x0))) (let ((buf x525) (inhibit-setup x526)) (progn (condition-case err (setq data (save-current-buffer ... ...)) (error (message "Fetch dir data failed with error: %s" err))) (if (buffer-live-p buf) (progn (save-current-buffer ... ... ... ...))))))))
  (let* ((x527 (car-safe x1)) (x528 (cdr-safe x1))) (let ((pb x527) (data x528)) (progn (ignore (consp x0)) (let* ((x525 (car-safe x0)) (x526 (cdr-safe x0))) (let ((buf x525) (inhibit-setup x526)) (progn (condition-case err (setq data ...) (error ...)) (if (buffer-live-p buf) (progn ...))))))))
  (progn (ignore (consp x1)) (let* ((x527 (car-safe x1)) (x528 (cdr-safe x1))) (let ((pb x527) (data x528)) (progn (ignore (consp x0)) (let* ((x525 (car-safe x0)) (x526 (cdr-safe x0))) (let ((buf x525) (inhibit-setup x526)) (progn (condition-case err ... ...) (if ... ...))))))))
  (let ((x0 (process-get p 'meta)) (x1 (cons (process-buffer p) nil))) (progn (ignore (consp x1)) (let* ((x527 (car-safe x1)) (x528 (cdr-safe x1))) (let ((pb x527) (data x528)) (progn (ignore (consp x0)) (let* ((x525 ...) (x526 ...)) (let (... ...) (progn (condition-case err (setq data (save-current-buffer (set-buffer pb) (read (buffer-string)))) (error (message "Fetch dir data failed with error: %s" err))) (if (buffer-live-p buf) (progn (save-current-buffer (set-buffer buf) (let* ((attrs (and t (cdr data))) (s (and attrs ...))) (if s (maphash #'... attrs))) (let* ((pair (assq :vc-backend dirvish--props)) (val (cdr pair))) (prog1 (setq val (or ... 0)) (if pair (setcdr (assq :vc-backend dirvish--props) val) (setq dirvish--props (cons (cons :vc-backend val) dirvish--props))))) (dirvish-data-for-dir dir buf inhibit-setup))))))))))))
  #f(lambda (p _) [(inhibit-setup nil) (dir "/Users/wd/.config/emacs/.local/straight/repos/dired-rsync/")] (let ((x0 (process-get p 'meta)) (x1 (cons (process-buffer p) nil))) (progn (ignore (consp x1)) (let* ((x527 (car-safe x1)) (x528 (cdr-safe x1))) (let ((pb x527) (data x528)) (progn (ignore (consp x0)) (let* ((x525 (car-safe x0)) (x526 (cdr-safe x0))) (let ((buf x525) (inhibit-setup x526)) (progn (condition-case err ... ...) (if ... ...))))))))) (delete-process p) (dirvish--kill-buffer (process-buffer p)))(#<process dirvish> "finished\n")
```

Disassemble:
```
byte code:
  doc:   ...
  args: (arg1 arg2)
0       constant  process-get
1       stack-ref 2
2       constant  meta
3       call      2
4       constant  process-buffer
5       stack-ref 3
6       call      1
7       list1     
8       dup       
9       car-safe  
10      stack-ref 1
11      cdr-safe  
12      dup       
13      stack-ref 4
14      car-safe  
15      stack-ref 5
16      cdr-safe  
17      constant  (error)
18      pushconditioncase 1
21      save-current-buffer 
22      stack-ref 4
23      set-buffer 
24      discard   
25      constant  read
26      constant  buffer-string
27      call      0
28      call      1
29      unbind    1
30      dup       
31      stack-set 4
33      pophandler 
34      discard   
35      goto      2
38:1    constant  message
39      constant  "Fetch dir data failed with error: %s"
40      stack-ref 2
41      call      2
42      discardN  2
44:2    constant  buffer-live-p
45      stack-ref 2
46      call      1
47      goto-if-nil 8
50      save-current-buffer 
51      stack-ref 1
52      set-buffer 
53      discard   
54      stack-ref 2
55      cdr       
56      dup       
57      goto-if-nil-else-pop 3
60      constant  hash-table-p
61      stack-ref 1
62      call      1
63:3    dup       
64      goto-if-nil 4
67      constant  maphash
68      constant  <byte-code-function>
      doc:   ...
      args: (arg1 arg2)
    0       constant  puthash
    1       stack-ref 2
    2       stack-ref 2
    3       varref    dirvish--dir-data
    4       call      3
    5       return    

69      stack-ref 3
70      call      2
71      discard   
72:4    discardN  2
74      constant  :vc-backend
75      varref    dirvish--props
76      assq      
77      dup       
78      cdr       
79      stack-ref 4
80      car       
81      goto-if-not-nil-else-pop 5
84      constant  0
85:5    stack-set 1
87      stack-ref 1
88      goto-if-nil 6
91      constant  :vc-backend
92      varref    dirvish--props
93      assq      
94      stack-ref 1
95      setcdr    
96      discardN  3
98      goto      7
101:6   constant  :vc-backend
102     stack-ref 1
103     cons      
104     varref    dirvish--props
105     cons      
106     varset    dirvish--props
107     discardN  2
109:7   constant  dirvish-data-for-dir
110     constant  "/Users/wd/Sync/org/work/zone/code/python/"
111     stack-ref 3
112     stack-ref 3
113     call      3
114     unbind    1
115     discard   
116:8   discardN  7
118     constant  delete-process
119     stack-ref 2
120     call      1
121     discard   
122     constant  dirvish--kill-buffer
123     constant  process-buffer
124     stack-ref 3
125     call      1
126     call      1
127     return    
```