### PR TITLE
Fix broken issue template by removing title field

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,6 +1,5 @@
 name: Bug Report
 description: Create a report to help us improve
-title: ""
 labels: "bug"
 body:
 - type: checkboxes


### PR DESCRIPTION
The title field cannot be empty and github shows a warning:

<img width="1193" height="173" alt="Screenshot from 2026-08-13 at 13_34_22 028698674" src="https://github.com/user-attachments/assets/73ed8914-72f9-462c-bbc8-7dece31afb82" />

Checking other repos, I see they don't specify the title field unless they want to encouraged a "Bug: " title prefix or something.
This fixes the template so that people a) get "Bug Report" as an issue type option when creating a new issue and b) can actually use the template